### PR TITLE
transactionを使うように修正

### DIFF
--- a/TanukiColiseum/Game.cs
+++ b/TanukiColiseum/Game.cs
@@ -230,6 +230,7 @@ namespace TanukiColiseum
                 using (var connection = new SQLiteConnection(builder.ToString()))
                 {
                     connection.Open();
+                    SQLiteTransaction transaction = connection.BeginTransaction();
                     using (var command = connection.CreateCommand())
                     {
                         command.CommandText = @"
@@ -300,6 +301,8 @@ VALUES ($game_id, $play, $best, $next, $value, $depth, $book)
                             command.ExecuteNonQuery();
                         }
                     }
+
+                    transaction.Commit();
                 }
             }
 


### PR DESCRIPTION
# 概要
SQLiteの出力時にtransactionを使うように修正。

# 期待する効果
SQLiteの出力時のファイルIOが大幅に改善する。
それによりファイルIOの待ち時間が減るので、CPU使用率の低下を防げる。
(いずれも計測などはしていないので詳細な変化は不明。同じ設定での計測終了までの時間は確かに短くなった。)