### PR TITLE
残りメモリ量のチェックを修正

### DIFF
--- a/TanukiColiseum/Coliseum.cs
+++ b/TanukiColiseum/Coliseum.cs
@@ -87,7 +87,7 @@ namespace TanukiColiseum
 				// 残り物理メモリ量 · Issue #13 · nodchip/TanukiColiseum https://github.com/nodchip/TanukiColiseum/issues/13
 				var currentAvailablePhysicalMemory = computerInfo.AvailablePhysicalMemory;
 				var consumedMemoryPerGame = previousAvailablePhysicalMemory - currentAvailablePhysicalMemory;
-				if (consumedMemoryPerGame > currentAvailablePhysicalMemory)
+				if (previousAvailablePhysicalMemory >= currentAvailablePhysicalMemory && consumedMemoryPerGame > currentAvailablePhysicalMemory)
 				{
 					ShowErrorMessage("利用可能物理メモリが足りません。同時対局数やハッシュサイズを下げてください。");
 					await FinishEnginesAsync(games);


### PR DESCRIPTION
残りメモリ量のチェックのコードで、`previousAvailablePhysicalMemory`が`currentAvailablePhysicalMemory`より小さい場合に、`ulong`であるためオーバーフローが生じ、メモリチェックに引っかかっていたのを修正しました。